### PR TITLE
Detect generic API keys

### DIFF
--- a/truffleHogRegexes/regexes.json
+++ b/truffleHogRegexes/regexes.json
@@ -11,5 +11,6 @@
     "Google Oauth": "(\"client_secret\":\"[a-zA-Z0-9-_]{24}\")",
     "AWS API Key": "AKIA[0-9A-Z]{16}",
     "Heroku API Key": "[h|H][e|E][r|R][o|O][k|K][u|U].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
-    "Generic Secret": "[s|S][e|E][c|C][r|R][e|E][t|T].*['|\"][0-9a-zA-Z]{32,45}['|\"]"
+    "Generic Secret": "[s|S][e|E][c|C][r|R][e|E][t|T].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
+    "Generic API Key": "[a|A][p|P][i|I][_]?[k|K][e|E][y|Y].*['|\"][0-9a-zA-Z]{32,45}['|\"]"
 }


### PR DESCRIPTION
Secrets often make their way into source code through a generic `XXX_API_KEY` that won't be detected through the existing regex set.  This change detects keys like the following:

```python
API_KEY = "012345678690123456786901234567869123"
```

Testing this on the repos I have access to I believe this to be high signal/noise. 