### PR TITLE
Adding a regexp for Google (GCP) service accounts

### DIFF
--- a/truffleHogRegexes/regexes.json
+++ b/truffleHogRegexes/regexes.json
@@ -13,5 +13,6 @@
     "Heroku API Key": "[h|H][e|E][r|R][o|O][k|K][u|U].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
     "Generic Secret": "[s|S][e|E][c|C][r|R][e|E][t|T].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
     "Generic API Key": "[a|A][p|P][i|I][_]?[k|K][e|E][y|Y].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
-    "Slack Webhook": "https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}"
+    "Slack Webhook": "https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
+    "Google (GCP) Service-account": "\"type\": \"service_account\""
 }


### PR DESCRIPTION
In GCP, you have [service accounts](https://cloud.google.com/iam/docs/service-accounts) that are used for system - system communication. The key that you can download to use for authentication is either a p12- or json-file. The json-file has the following structure:
```
{
  "type": "service_account",
  "project_id": "<gcp_project_id>",
  "private_key_id": "<private_key_id>",
  "private_key": "-----BEGIN PRIVATE KEY-----\n<key>\n-----END PRIVATE KEY-----\n",
  "client_email": "<service_account_email>",
  "client_id": "<client_id>",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://accounts.google.com/o/oauth2/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<service_account_email>"
}
```
I added a regexp to find `"type": "service_account"`. A generic regexp for finding `-----BEGIN PRIVATE KEY-----` would also work if you prefer it.

Ping @dxa4481 