### PR TITLE
Add regexes for password in url and twilio

### DIFF
--- a/truffleHogRegexes/regexes.json
+++ b/truffleHogRegexes/regexes.json
@@ -13,5 +13,6 @@
     "Heroku API Key": "[h|H][e|E][r|R][o|O][k|K][u|U].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
     "Generic Secret": "[s|S][e|E][c|C][r|R][e|E][t|T].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
     "Generic API Key": "[a|A][p|P][i|I][_]?[k|K][e|E][y|Y].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
-    "Slack Webhook": "https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}"
+    "Slack Webhook": "https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
+    "Twilio API Key": "SK[a-z0-9]{32}"
 }

--- a/truffleHogRegexes/regexes.json
+++ b/truffleHogRegexes/regexes.json
@@ -14,5 +14,6 @@
     "Generic Secret": "[s|S][e|E][c|C][r|R][e|E][t|T].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
     "Generic API Key": "[a|A][p|P][i|I][_]?[k|K][e|E][y|Y].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
     "Slack Webhook": "https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
-    "Twilio API Key": "SK[a-z0-9]{32}"
+    "Twilio API Key": "SK[a-z0-9]{32}",
+    "Password in URL": "//[^/\\s:]+:[^/\\s:]+@"
 }


### PR DESCRIPTION
Classify Twilio API keys (they were found previously as generic secrets), and also identify basic auth passwords in urls (eg http://username:password@example.com; also finds mysql://, ftp://, jdbc://, etc). 