### PR TITLE
fix: prevent matching pipe character in character classes

### DIFF
--- a/truffleHogRegexes/regexes.json
+++ b/truffleHogRegexes/regexes.json
@@ -10,7 +10,7 @@
     "Facebook Access Token": "EAACEdEose0cBA[0-9A-Za-z]+",
     "Facebook OAuth": "[fF][aA][cC][eE][bB][oO][oO][kK].*['|\"][0-9a-f]{32}['|\"]",
     "GitHub": "[gG][iI][tT][hH][uU][bB].*['|\"][0-9a-zA-Z]{35,40}['|\"]",
-    "Generic API Key": "[aA][pP][iI][_]?[kK][eE][yY].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
+    "Generic API Key": "[aA][pP][iI]_?[kK][eE][yY].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
     "Generic Secret": "[sS][eE][cC][rR][eE][tT].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
     "Google API Key": "AIza[0-9A-Za-z\\-_]{35}",
     "Google Cloud Platform API Key": "AIza[0-9A-Za-z\\-_]{35}",

--- a/truffleHogRegexes/regexes.json
+++ b/truffleHogRegexes/regexes.json
@@ -1,5 +1,5 @@
 {
-    "Slack Token": "(xox[p|b|o|a]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})",
+    "Slack Token": "(xox[pboa]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})",
     "RSA private key": "-----BEGIN RSA PRIVATE KEY-----",
     "SSH (DSA) private key": "-----BEGIN DSA PRIVATE KEY-----",
     "SSH (EC) private key": "-----BEGIN EC PRIVATE KEY-----",
@@ -8,10 +8,10 @@
     "Amazon MWS Auth Token": "amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
     "AWS API Key": "AKIA[0-9A-Z]{16}",
     "Facebook Access Token": "EAACEdEose0cBA[0-9A-Za-z]+",
-    "Facebook OAuth": "[f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K].*['|\"][0-9a-f]{32}['|\"]",
-    "GitHub": "[g|G][i|I][t|T][h|H][u|U][b|B].*['|\"][0-9a-zA-Z]{35,40}['|\"]",
-    "Generic API Key": "[a|A][p|P][i|I][_]?[k|K][e|E][y|Y].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
-    "Generic Secret": "[s|S][e|E][c|C][r|R][e|E][t|T].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
+    "Facebook OAuth": "[fF][aA][cC][eE][bB][oO][oO][kK].*['|\"][0-9a-f]{32}['|\"]",
+    "GitHub": "[gG][iI][tT][hH][uU][bB].*['|\"][0-9a-zA-Z]{35,40}['|\"]",
+    "Generic API Key": "[aA][pP][iI][_]?[kK][eE][yY].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
+    "Generic Secret": "[sS][eE][cC][rR][eE][tT].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
     "Google API Key": "AIza[0-9A-Za-z\\-_]{35}",
     "Google Cloud Platform API Key": "AIza[0-9A-Za-z\\-_]{35}",
     "Google Cloud Platform OAuth": "[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com",
@@ -23,7 +23,7 @@
     "Google OAuth Access Token": "ya29\\.[0-9A-Za-z\\-_]+",
     "Google YouTube API Key": "AIza[0-9A-Za-z\\-_]{35}",
     "Google YouTube OAuth": "[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com",
-    "Heroku API Key": "[h|H][e|E][r|R][o|O][k|K][u|U].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
+    "Heroku API Key": "[hH][eE][rR][oO][kK][uU].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
     "MailChimp API Key": "[0-9a-f]{32}-us[0-9]{1,2}",
     "Mailgun API Key": "key-[0-9a-zA-Z]{32}",
     "Password in URL": "[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}[\"'\\s]",
@@ -35,6 +35,6 @@
     "Square Access Token": "sq0atp-[0-9A-Za-z\\-_]{22}",
     "Square OAuth Secret": "sq0csp-[0-9A-Za-z\\-_]{43}",
     "Twilio API Key": "SK[0-9a-fA-F]{32}",
-    "Twitter Access Token": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*[1-9][0-9]+-[0-9a-zA-Z]{40}",
-    "Twitter OAuth": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*['|\"][0-9a-zA-Z]{35,44}['|\"]"
+    "Twitter Access Token": "[tT][wW][iI][tT][tT][eE][rR].*[1-9][0-9]+-[0-9a-zA-Z]{40}",
+    "Twitter OAuth": "[tT][wW][iI][tT][tT][eE][rR].*['|\"][0-9a-zA-Z]{35,44}['|\"]"
 }


### PR DESCRIPTION
In regex, `|` denotes alternates within groups. Within a character class, the pipe is not needed and is instead treated as a character of the class. For example, `xox[p|b|o|a]` would match `xoxp` and `xoxb` as expected, but also `xox|` which is not. This could lead to false positive matches.

A minor edit was also added for an unneeded character class with a single character.