### PR TITLE
Add AWS AppSync GraphQL keys

### DIFF
--- a/truffleHogRegexes/regexes.json
+++ b/truffleHogRegexes/regexes.json
@@ -7,6 +7,7 @@
     "Amazon AWS Access Key ID": "AKIA[0-9A-Z]{16}",
     "Amazon MWS Auth Token": "amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
     "AWS API Key": "AKIA[0-9A-Z]{16}",
+    "AWS AppSync GraphQL Key": "da2-[a-z0-9]{26}",
     "Facebook Access Token": "EAACEdEose0cBA[0-9A-Za-z]+",
     "Facebook OAuth": "[f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K].*['|\"][0-9a-f]{32}['|\"]",
     "GitHub": "[g|G][i|I][t|T][h|H][u|U][b|B].*['|\"][0-9a-zA-Z]{35,40}['|\"]",


### PR DESCRIPTION
Add AWS AppSync GraphQL keys

This keys are used to talk with GraphQL endpoints on AWS
https://docs.aws.amazon.com/appsync/latest/APIReference/API_ApiKey.html